### PR TITLE
Refactor, fix bug when switching between 'Any' and 'Property'

### DIFF
--- a/lib/flipper/ui/public/js/application.js
+++ b/lib/flipper/ui/public/js/application.js
@@ -1,227 +1,390 @@
-document.addEventListener("DOMContentLoaded", function () {
-  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) {
-    new bootstrap.Tooltip(el)
-  })
+// Constants
+const SELECTORS = {
+  TOOLTIP: '[data-bs-toggle="tooltip"]',
+  TOGGLE_TRIGGER: '.js-toggle-trigger',
+  TOGGLE_CONTAINER: '.js-toggle-container',
+  CONFIRMATION_ELEMENT: '*[data-confirmation-text]',
+  EXPRESSION_FORM: 'expression-form',
+  EXPRESSION_TYPE_RADIOS: 'input[name="expression_type"]',
+  SIMPLE_FORM: 'simple-expression-form',
+  COMPLEX_FORM: 'complex-expression-form',
+  ADD_EXPRESSION_BTN: 'add-expression-btn',
+  EXPRESSION_LIST: 'expression-list',
+  EXPRESSION_FORM_DATA: 'expression-form-data',
+  EXPRESSION_ROW_TEMPLATE: 'expression-row-template',
+  REMOVE_EXPRESSION_BTN: '.remove-expression-btn',
+  EXPRESSION_ROWS: '.row',
+  EXPRESSION_TYPE_CHECKED: 'input[name="expression_type"]:checked'
+};
 
-  document.querySelectorAll(".js-toggle-trigger").forEach(function (trigger) {
-    trigger.addEventListener("click", function () {
-      var container = this.closest(".js-toggle-container");
-      container.classList.toggle("toggle-on");
-    });
-  });
+const CSS_CLASSES = {
+  TOGGLE_ON: 'toggle-on',
+  HIDDEN: 'd-none'
+};
 
-  document.querySelectorAll("*[data-confirmation-text]").forEach(function (element) {
-    element.addEventListener("click", function (e) {
-      var expected = e.target.getAttribute("data-confirmation-text");
-      var actual = prompt(e.target.getAttribute("data-confirmation-prompt"));
+const EXPRESSION_TYPES = {
+  PROPERTY: 'property',
+  ANY: 'any',
+  ALL: 'all'
+};
 
-      if (expected !== actual) {
-        e.preventDefault();
+const MESSAGES = {
+  ADD_EXPRESSION_TOOLTIP: 'Add Expression is only available for Any/All expression types',
+  REMOVE_LAST_EXPRESSION: 'Cannot remove the last expression',
+  NO_EXPRESSIONS_ERROR: 'Please add at least one expression.'
+};
+
+const TooltipManager = {
+  initializeAll() {
+    const tooltipElements = document.querySelectorAll(SELECTORS.TOOLTIP);
+    tooltipElements.forEach(element => {
+      try {
+        new bootstrap.Tooltip(element);
+      } catch (error) {
+        console.warn('Failed to initialize tooltip', error);
       }
     });
-  });
+  },
 
-  // Expression form handling
-  var expressionForm = document.getElementById("expression-form");
-  if (expressionForm) {
-    var typeRadios = document.querySelectorAll('input[name="expression_type"]');
-    var simpleForm = document.getElementById("simple-expression-form");
-    var complexForm = document.getElementById("complex-expression-form");
-    var addExpressionBtn = document.getElementById("add-expression-btn");
-    var expressionList = document.getElementById("expression-list");
-    var expressionCounter = 0;
+  create(element, title) {
+    if (!element) return null;
 
-    // Helper functions to manage tooltip state for add expression button
-    function showAddExpressionTooltip() {
-      if (!addExpressionBtn) return;
-      
-      var tooltipWrapper = addExpressionBtn.parentElement;
-      if (!tooltipWrapper) return;
+    try {
+      this.destroy(element);
+      element.setAttribute('data-bs-toggle', 'tooltip');
+      element.title = title;
+      return new bootstrap.Tooltip(element);
+    } catch (error) {
+      console.warn('Failed to create tooltip', error);
+      return null;
+    }
+  },
 
-      // Destroy existing tooltip instance
-      var existingTooltip = bootstrap.Tooltip.getInstance(tooltipWrapper);
+  destroy(element) {
+    if (!element) return;
+
+    try {
+      const existingTooltip = bootstrap.Tooltip.getInstance(element);
       if (existingTooltip) {
         existingTooltip.dispose();
       }
-
-      // Button is disabled - show tooltip
-      addExpressionBtn.disabled = true;
-      addExpressionBtn.title = "Add Expression is only available for Any/All expression types";
-      tooltipWrapper.setAttribute('data-bs-toggle', 'tooltip');
-      new bootstrap.Tooltip(tooltipWrapper);
+      element.removeAttribute('data-bs-toggle');
+      element.title = '';
+    } catch (error) {
+      console.warn('Failed to destroy tooltip', error);
     }
+  }
+};
 
-    function hideAddExpressionTooltip() {
-      if (!addExpressionBtn) return;
-      
-      var tooltipWrapper = addExpressionBtn.parentElement;
-      if (!tooltipWrapper) return;
+const ToggleHandler = {
+  initializeAll() {
+    const triggers = document.querySelectorAll(SELECTORS.TOGGLE_TRIGGER);
+    triggers.forEach(trigger => {
+      trigger.addEventListener('click', this.handleToggle.bind(this));
+    });
+  },
 
-      // Destroy existing tooltip instance
-      var existingTooltip = bootstrap.Tooltip.getInstance(tooltipWrapper);
-      if (existingTooltip) {
-        existingTooltip.dispose();
+  handleToggle(event) {
+    try {
+      const container = event.target.closest(SELECTORS.TOGGLE_CONTAINER);
+      if (container) {
+        container.classList.toggle(CSS_CLASSES.TOGGLE_ON);
       }
-
-      // Button is enabled - remove tooltip
-      addExpressionBtn.disabled = false;
-      addExpressionBtn.title = "";
-      tooltipWrapper.removeAttribute('data-bs-toggle');
+    } catch (error) {
+      console.warn('Failed to handle toggle', error);
     }
+  }
+};
 
-    // Update remove button states based on number of expressions
-    function updateRemoveButtonStates() {
-      var expressionRows = expressionList.querySelectorAll(".row");
-      var removeButtons = expressionList.querySelectorAll(".remove-expression-btn");
+// Manages confirmation prompts for destructive actions
+const ConfirmationHandler = {
+  initializeAll() {
+    const elements = document.querySelectorAll(SELECTORS.CONFIRMATION_ELEMENT);
+    elements.forEach(element => {
+      element.addEventListener('click', this.handleConfirmation.bind(this));
+    });
+  },
 
-      removeButtons.forEach(function(btn) {
-        if (expressionRows.length <= 1) {
-          btn.disabled = true;
-          btn.title = "Cannot remove the last expression";
-        } else {
-          btn.disabled = false;
-          btn.title = "";
-        }
-      });
+  handleConfirmation(event) {
+    try {
+      const target = event.target;
+      const expectedText = target.getAttribute('data-confirmation-text');
+      const promptText = target.getAttribute('data-confirmation-prompt');
+      
+      if (!expectedText || !promptText) return;
+
+      const userInput = prompt(promptText);
+      
+      if (expectedText !== userInput) {
+        event.preventDefault();
+      }
+    } catch (error) {
+      console.warn('Failed to handle confirmation', error);
+      event.preventDefault();
     }
+  }
+};
 
-    // Initialize form with existing data
-    var formDataScript = document.getElementById("expression-form-data");
-    var formData = formDataScript ? JSON.parse(formDataScript.textContent) : { type: "property" };
+class ExpressionFormManager {
+  constructor() {
+    this.form = document.getElementById(SELECTORS.EXPRESSION_FORM);
+    this.typeRadios = document.querySelectorAll(SELECTORS.EXPRESSION_TYPE_RADIOS);
+    this.simpleForm = document.getElementById(SELECTORS.SIMPLE_FORM);
+    this.complexForm = document.getElementById(SELECTORS.COMPLEX_FORM);
+    this.addExpressionBtn = document.getElementById(SELECTORS.ADD_EXPRESSION_BTN);
+    this.expressionList = document.getElementById(SELECTORS.EXPRESSION_LIST);
+    this.expressionCounter = 0;
     
+    if (this.form) {
+      this.initialize();
+    }
+  }
+
+  initialize() {
+    try {
+      this.loadFormData();
+      this.initializeFormState();
+      this.bindEventListeners();
+    } catch (error) {
+      console.error('Failed to initialize expression form', error);
+    }
+  }
+
+  loadFormData() {
+    const formDataScript = document.getElementById(SELECTORS.EXPRESSION_FORM_DATA);
+    const formData = formDataScript
+      ? JSON.parse(formDataScript.textContent)
+      : { type: EXPRESSION_TYPES.PROPERTY };
+
     // Initialize complex expressions if they exist
     if (formData.expressions && formData.expressions.length > 0) {
-      formData.expressions.forEach(function(expr) {
-        addExpressionRow(expr.property, expr.operator, expr.value);
+      formData.expressions.forEach(expr => {
+        this.addExpressionRow(expr.property, expr.operator, expr.value);
       });
-      updateRemoveButtonStates();
+      this.updateRemoveButtonStates();
     }
+  }
 
-    // Initialize form state based on checked radio button
-    var checkedRadio = document.querySelector('input[name="expression_type"]:checked');
+  // Initialize form state based on selected radio button
+  initializeFormState() {
+    const checkedRadio = document.querySelector(SELECTORS.EXPRESSION_TYPE_CHECKED);
     if (checkedRadio) {
-      if (checkedRadio.value === "property") {
-        simpleForm.classList.remove("d-none");
-        complexForm.classList.add("d-none");
-        showAddExpressionTooltip(); // Button disabled, show tooltip
-      } else {
-        simpleForm.classList.add("d-none");
-        complexForm.classList.remove("d-none");
-        hideAddExpressionTooltip(); // Button enabled, hide tooltip
-        // Update button states if there are existing expressions
-        updateRemoveButtonStates();
-      }
+      this.handleExpressionTypeChange(checkedRadio.value);
     }
+  }
 
-    // Handle expression type changes
-    typeRadios.forEach(function(radio) {
-      radio.addEventListener("change", function() {
-        if (this.value === "property") {
-          simpleForm.classList.remove("d-none");
-          complexForm.classList.add("d-none");
-          showAddExpressionTooltip(); // Button disabled, show tooltip
-        } else {
-          simpleForm.classList.add("d-none");
-          complexForm.classList.remove("d-none");
-          hideAddExpressionTooltip(); // Button enabled, hide tooltip
-          // Add initial expression if none exist
-          if (expressionList.children.length === 0) {
-            addExpressionRow();
-          }
-        }
+  bindEventListeners() {
+    this.typeRadios.forEach(radio => { // Expression type radio buttons
+      radio.addEventListener('change', () => {
+        this.handleExpressionTypeChange(radio.value);
       });
     });
 
-    // Add expression row for complex forms
-    function addExpressionRow(property, operator, value) {
-      var template = document.getElementById("expression-row-template");
-      var row = template.content.cloneNode(true);
-
-      // Update the counter in name attributes
-      var selects = row.querySelectorAll("select");
-      var inputs = row.querySelectorAll("input");
-
-      selects.forEach(function(select) {
-        select.name = select.name.replace("COUNTER", expressionCounter);
+    if (this.addExpressionBtn) {
+      this.addExpressionBtn.addEventListener('click', () => {
+        this.addExpressionRow();
       });
+    }
 
-      inputs.forEach(function(input) {
-        input.name = input.name.replace("COUNTER", expressionCounter);
-      });
+    this.form.addEventListener('submit', this.handleFormSubmission.bind(this));
+  }
 
-      // Set initial values before adding to DOM
-      var propertySelect = row.querySelector('select[name*="property_name"]');
-      var operatorSelect = row.querySelector('select[name*="operator_class"]');
-      var valueInput = row.querySelector('input[name*="value"]');
+  handleExpressionTypeChange(type) {
+    if (type === EXPRESSION_TYPES.PROPERTY) {
+      this.showSimpleForm();
+      this.showAddExpressionTooltip();
+    } else {
+      this.showComplexForm();
+      this.hideAddExpressionTooltip();
       
-      if (valueInput) {
-        valueInput.value = value || '';
+      // Add initial expression if none exist
+      if (this.expressionList && this.expressionList.children.length === 0) {
+        this.addExpressionRow();
       }
-
-      // Add event listener to remove button
-      var removeBtn = row.querySelector(".remove-expression-btn");
-      removeBtn.addEventListener("click", function() {
-        removeBtn.closest(".row").remove();
-        updateRemoveButtonStates();
-      });
-
-      expressionList.appendChild(row);
-      
-      // Set select values after adding to DOM to ensure proper selection
-      // Query the elements from the DOM after they've been added
-      setTimeout(function() {
-        var addedPropertySelect = expressionList.querySelector('select[name="complex_expressions[' + expressionCounter + '][property_name]"]');
-        var addedOperatorSelect = expressionList.querySelector('select[name="complex_expressions[' + expressionCounter + '][operator_class]"]');
-        
-        if (addedPropertySelect) {
-          if (property) {
-            addedPropertySelect.value = property;
-          } else {
-            // Ensure the first option (placeholder) is selected when no property is provided
-            addedPropertySelect.value = '';
-            addedPropertySelect.selectedIndex = 0;
-          }
-        }
-        
-        if (addedOperatorSelect) {
-          if (operator) {
-            addedOperatorSelect.value = operator;
-          } else {
-            // Ensure the first option (placeholder) is selected when no operator is provided
-            addedOperatorSelect.value = '';
-            addedOperatorSelect.selectedIndex = 0;
-          }
-        }
-      }, 0);
-      
-      expressionCounter++;
-      updateRemoveButtonStates();
     }
+  }
 
-    // Add expression button click handler
-    if (addExpressionBtn) {
-      addExpressionBtn.addEventListener("click", addExpressionRow);
-    }
+  // Show simple form and hide complex form
+  showSimpleForm() {
+    if (this.simpleForm) this.simpleForm.classList.remove(CSS_CLASSES.HIDDEN);
+    if (this.complexForm) this.complexForm.classList.add(CSS_CLASSES.HIDDEN);
+  }
 
-    // Form submission handling for complex expressions
-    expressionForm.addEventListener("submit", function(e) {
-      var selectedType = document.querySelector('input[name="expression_type"]:checked');
-      if (selectedType && (selectedType.value === "any" || selectedType.value === "all")) {
-        // Validate at least one expression exists
-        var expressions = expressionList.querySelectorAll(".row");
-        if (expressions.length === 0) {
-          e.preventDefault();
-          alert("Please add at least one expression.");
-          return;
-        }
+  // Show complex form and hide simple form
+  showComplexForm() {
+    if (this.simpleForm) this.simpleForm.classList.add(CSS_CLASSES.HIDDEN);
+    if (this.complexForm) this.complexForm.classList.remove(CSS_CLASSES.HIDDEN);
+    this.updateRemoveButtonStates();
+  }
 
-        // Add hidden input for expression type
-        var typeInput = document.createElement("input");
-        typeInput.type = "hidden";
-        typeInput.name = "complex_expression_type";
-        typeInput.value = selectedType.value;
-        expressionForm.appendChild(typeInput);
+  showAddExpressionTooltip() {
+    if (!this.addExpressionBtn) return;
+
+    const tooltipWrapper = this.addExpressionBtn.parentElement;
+    if (!tooltipWrapper) return;
+
+    this.addExpressionBtn.disabled = true;
+    TooltipManager.create(tooltipWrapper, MESSAGES.ADD_EXPRESSION_TOOLTIP);
+  }
+
+  hideAddExpressionTooltip() {
+    if (!this.addExpressionBtn) return;
+
+    const tooltipWrapper = this.addExpressionBtn.parentElement;
+    if (!tooltipWrapper) return;
+
+    this.addExpressionBtn.disabled = false;
+    TooltipManager.destroy(tooltipWrapper);
+  }
+
+  // Update remove button states based on number of expressions
+  updateRemoveButtonStates() {
+    if (!this.expressionList) return;
+
+    const expressionRows = this.expressionList.querySelectorAll(SELECTORS.EXPRESSION_ROWS);
+    const removeButtons = this.expressionList.querySelectorAll(SELECTORS.REMOVE_EXPRESSION_BTN);
+
+    removeButtons.forEach(btn => {
+      if (expressionRows.length <= 1) {
+        btn.disabled = true;
+        btn.title = MESSAGES.REMOVE_LAST_EXPRESSION;
+      } else {
+        btn.disabled = false;
+        btn.title = '';
       }
     });
   }
+
+  // Add a new expression row (for Any/All expressions)
+  addExpressionRow(property = '', operator = '', value = '') {
+    if (!this.expressionList) return;
+
+    const template = document.getElementById(SELECTORS.EXPRESSION_ROW_TEMPLATE);
+    if (!template) return;
+
+    try {
+      const row = template.content.cloneNode(true);
+      
+      this.updateRowCounters(row); // Update counter in name attributes
+      this.setRowValues(row, value); // Set initial values
+      this.addRemoveButtonListener(row); // Add remove button listener
+      this.expressionList.appendChild(row); // Append to list
+      this.setSelectValues(property, operator, this.expressionCounter); // Set select values after DOM insertion
+      this.expressionCounter++;
+      this.updateRemoveButtonStates();
+    } catch (error) {
+      console.error('Failed to add expression row', error);
+    }
+  }
+
+  // Update counter placeholders in row elements
+  updateRowCounters(row) {
+    const selects = row.querySelectorAll('select');
+    const inputs = row.querySelectorAll('input');
+
+    [...selects, ...inputs].forEach(element => {
+      if (element.name) {
+        element.name = element.name.replace('COUNTER', this.expressionCounter);
+      }
+    });
+  }
+
+  // Set initial values for row inputs
+  setRowValues(row, value) {
+    const valueInput = row.querySelector('input[name*="value"]');
+    if (valueInput) {
+      valueInput.value = value || '';
+    }
+  }
+
+  addRemoveButtonListener(row) {
+    const removeBtn = row.querySelector(SELECTORS.REMOVE_EXPRESSION_BTN);
+    if (removeBtn) {
+      removeBtn.addEventListener('click', () => {
+        const rowElement = removeBtn.closest(SELECTORS.EXPRESSION_ROWS);
+        if (rowElement) {
+          rowElement.remove();
+          this.updateRemoveButtonStates();
+        }
+      });
+    }
+  }
+
+  setSelectValues(property, operator, counter = this.expressionCounter) {
+    // Use setTimeout to ensure DOM is fully updated first
+    setTimeout(() => {
+      const propertySelect = this.expressionList.querySelector(
+        `select[name="complex_expressions[${counter}][property_name]"]`
+      );
+      const operatorSelect = this.expressionList.querySelector(
+        `select[name="complex_expressions[${counter}][operator_class]"]`
+      );
+
+      if (propertySelect) {
+        propertySelect.value = property || '';
+        if (!property) propertySelect.selectedIndex = 0;
+      }
+
+      if (operatorSelect) {
+        operatorSelect.value = operator || '';
+        if (!operator) operatorSelect.selectedIndex = 0;
+      }
+    }, 0);
+  }
+
+  handleFormSubmission(event) {
+    try {
+      const selectedType = document.querySelector(SELECTORS.EXPRESSION_TYPE_CHECKED);
+      
+      if (selectedType && (selectedType.value === EXPRESSION_TYPES.ANY || selectedType.value === EXPRESSION_TYPES.ALL)) {
+        if (!this.validateExpressions(event)) return;
+        this.addHiddenTypeInput(selectedType.value);
+      }
+    } catch (error) {
+      console.error('Failed to handle form submission', error);
+      event.preventDefault();
+    }
+  }
+
+  // Validate that at least one expression exists
+  validateExpressions(event) {
+    if (!this.expressionList) return false;
+
+    const expressions = this.expressionList.querySelectorAll(SELECTORS.EXPRESSION_ROWS);
+    if (expressions.length === 0) {
+      event.preventDefault();
+      alert(MESSAGES.NO_EXPRESSIONS_ERROR);
+      return false;
+    }
+    return true;
+  }
+
+  addHiddenTypeInput(value) {
+    const typeInput = document.createElement('input');
+    typeInput.type = 'hidden';
+    typeInput.name = 'complex_expression_type';
+    typeInput.value = value;
+    this.form.appendChild(typeInput);
+  }
+}
+
+// Application Initializer: main entry point for Flipper UI
+const FlipperUIApp = {
+  initialize() {
+    try {
+      TooltipManager.initializeAll();
+      ToggleHandler.initializeAll();
+      ConfirmationHandler.initializeAll();
+      
+      new ExpressionFormManager();
+      
+      console.log('Flipper UI Application initialized successfully');
+    } catch (error) {
+      console.error('Failed to initialize Flipper UI Application', error);
+    }
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  FlipperUIApp.initialize();
 });

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -326,8 +326,8 @@
                         <% Flipper::UI.expression_properties.each do |property, config| %>
                           <option value="<%= property %>" <%= "selected" if @feature.expression_form_data[:property] == property.to_s %>><%= property %></option>
                         <% end %>
-                        <% if @feature.expression_form_data[:property] && !Flipper::UI.expression_properties.has_key?(@feature.expression_form_data[:property].to_sym) %>
-                          <option value="<%= @feature.expression_form_data[:property] %>" selected><%= @feature.expression_form_data[:property] %> (no longer available)</option>
+                        <% if @feature.expression_form_data[:property] && !Flipper::UI.expression_properties.has_key?(@feature.expression_form_data[:property].to_s) && !Flipper::UI.expression_properties.has_key?(@feature.expression_form_data[:property].to_sym) %>
+                          <option value="<%= @feature.expression_form_data[:property] %>" selected disabled><%= @feature.expression_form_data[:property] %> (no longer available)</option>
                         <% end %>
                       </select>
                     </div>

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -331,7 +331,7 @@
                         <% end %>
                       </select>
                     </div>
-                    <div class="col-md-3 mb-3">
+                    <div class="col-md-4 mb-3">
                       <select name="operator_class" class="form-select">
                         <option value="">Select an operator...</option>
                         <option value="Equal" <%= "selected" if @feature.expression_form_data[:operator] == "Equal" %>>equals (=)</option>
@@ -342,7 +342,7 @@
                         <option value="LessThanOrEqualTo" <%= "selected" if @feature.expression_form_data[:operator] == "LessThanOrEqualTo" %>>less than or equal (<=)</option>
                       </select>
                     </div>
-                    <div class="col-md-3 mb-3">
+                    <div class="col-md-2 mb-3">
                       <input type="text" name="value" placeholder="value" class="form-control" value="<%= @feature.expression_form_data[:value] %>">
                     </div>
                     <div class="col-auto ms-auto mb-3">
@@ -387,7 +387,7 @@
                       <% end %>
                     </select>
                   </div>
-                  <div class="col-md-3 mb-3">
+                  <div class="col-md-4 mb-3">
                     <select name="complex_expressions[COUNTER][operator_class]" class="form-select" required>
                       <option value="">Select an operator...</option>
                       <option value="Equal">equals (=)</option>
@@ -398,7 +398,7 @@
                       <option value="LessThanOrEqualTo">less than or equal (<=)</option>
                     </select>
                   </div>
-                  <div class="col-md-3 mb-3">
+                  <div class="col-md-2 mb-3">
                     <input type="text" name="complex_expressions[COUNTER][value]" placeholder="value" class="form-control" required>
                   </div>
                   <div class="col-auto ms-auto mb-3">


### PR DESCRIPTION
1. Refactor application.js to use `initialize` pattern, and add comments. It's arguably more readable but a lot more verbose so not sure how I'm feeling about it. 
2. Fixed property and operator dropdowns reverting to defaults when editing existing expressions. Modified addExpressionRow() to pass counter value to setSelectValues() before incrementing.